### PR TITLE
Add beginning of a test suite.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: python
+sudo: false
+python:
+  - 2.7
+  - 3.4
+  - 3.5
+  - pypy
+script:
+  - zope-testrunner --test-path=.  --auto-color --auto-progress
+
+install:
+  - pip install -U pip
+  - pip install -U setuptools
+  - pip install -U -e ".[test]"
+
+# cache: pip seems not to work if `install` is replaced (https://github.com/travis-ci/travis-ci/issues/3239)
+cache:
+  directories:
+    - $HOME/.cache/pip
+
+before_cache:
+    - rm -f $HOME/.cache/pip/log/debug.log

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ repoze.sphinx.autointerface Changelog
 0.8.1 (unreleased)
 ------------------
 
-- TBD
+- Drop support for Sphinx < 1.0.
 
 0.8 (2016-03-28)
 ----------------

--- a/repoze/sphinx/tests/root/conf.py
+++ b/repoze/sphinx/tests/root/conf.py
@@ -1,0 +1,1 @@
+extensions = ['sphinx.ext.autodoc']

--- a/repoze/sphinx/tests/test_autointerface.py
+++ b/repoze/sphinx/tests/test_autointerface.py
@@ -1,0 +1,98 @@
+import unittest
+
+from .util import TestApp
+
+from .. import autointerface
+from sphinx.ext.autodoc import AutoDirective, ALL
+
+from docutils.statemachine import ViewList
+
+from zope import interface
+
+class IPlumbusMaker(interface.Interface):
+
+    grumbo = interface.Attribute("The dinglebop is fed through here")
+    fleeb = interface.Attribute("The dinglebop is polished with this")
+
+    def smoothTheDinglebop(schleem):
+        """
+        Smooth it out.
+
+        The schleem is then repurposed.
+        """
+
+class Options(object):
+    inherited_members = False
+    undoc_members = False
+    private_members = False
+    special_members = False
+    imported_members = False
+    show_inheritance = False
+    noindex = False
+    annotation = None
+    synopsis = ''
+    platform = ''
+    deprecated = False
+    members = ()
+    member_order = 'alphabetic'
+    exclude_members = ()
+
+    def __init__(self):
+        self.exclude_members = set()
+        self.members = []
+
+class Directive(object):
+    env = None
+    genopt = None
+    result = None
+
+    def __init__(self):
+        self._warnings = []
+        self.filename_set = set()
+        self.result = ViewList()
+
+    def warn(self, msg):
+        self._warnings.append(msg)
+
+class TestAutoInterface(unittest.TestCase):
+
+    def setUp(self):
+        app = self.app = TestApp()
+        app.builder.env.app = app
+        app.builder.env.temp_data['docname'] = 'dummy'
+
+        autointerface.setup(app)
+
+        opt = self.options = Options()
+        d = self.directive = Directive()
+        d.env = app.builder.env
+        d.genopt = opt
+
+
+    def tearDown(self):
+        self.app.cleanup()
+        self.app = None
+
+    def assertResultContains(self, item,
+                             objtype='interface', name='repoze.sphinx.tests.test_autointerface.IPlumbusMaker',
+                             **kw):
+        directive = self.directive
+        inst = AutoDirective._registry[objtype](directive, name)
+        inst.generate(**kw)
+        # print '\n'.join(directive.result)
+        self.assertEqual([], directive._warnings)
+        self.assertIn(item, directive.result)
+        results = directive.result[:]
+        del directive.result[:]
+        return '\n'.join(results)
+
+    def test_restricted_members(self):
+        self.options.members = ['smoothTheDinglebop']
+        all_results = self.assertResultContains('   .. method:: smoothTheDinglebop(schleem)')
+        self.assertNotIn('grumbo', all_results)
+
+    def test_all_members(self):
+        self.options.members = ALL
+        all_results = self.assertResultContains('   .. method:: smoothTheDinglebop(schleem)')
+        self.assertIn('grumbo', all_results)
+        self.assertIn('fleeb', all_results)

--- a/repoze/sphinx/tests/util.py
+++ b/repoze/sphinx/tests/util.py
@@ -1,0 +1,116 @@
+import sys
+import os
+import tempfile
+import shutil
+
+from six import StringIO
+
+from sphinx import application
+from sphinx.builders.latex import LaTeXBuilder
+from sphinx.theming import Theme
+from sphinx.ext.autodoc import AutoDirective
+from sphinx.pycode import ModuleAnalyzer
+
+from docutils import nodes
+from docutils.parsers.rst import directives, roles
+
+rootdir = os.path.abspath(os.path.dirname(__file__) or '.')
+
+class ListOutput(object):
+    """
+    File-like object that collects written text in a list.
+    """
+    def __init__(self, name):
+        self.name = name
+        self.content = []
+
+    def reset(self):
+        del self.content[:]
+
+    def write(self, text):
+        self.content.append(text)
+
+class TestApp(application.Sphinx):
+    """
+    A subclass of :class:`Sphinx` that runs on the test root, with some
+    better default values for the initialization parameters.
+    """
+
+    def __init__(self, buildername='html', testroot=None, srcdir=None,
+                 freshenv=False, confoverrides=None, status=None, warning=None,
+                 tags=None, docutilsconf=None):
+        if testroot is None:
+            defaultsrcdir = 'root'
+            testroot = os.path.join(rootdir, 'root')
+        else:
+            defaultsrcdir = 'test-' + testroot
+            testroot = os.path.join(rootdir, 'roots', ('test-' + testroot))
+
+        self.__tempdir = os.path.abspath(tempfile.mkdtemp())
+
+
+        if srcdir is None:
+            srcdir = os.path.join(self.__tempdir, defaultsrcdir)
+        else:
+            srcdir = os.path.join(self.__tempdir, srcdir)
+
+        if not os.path.exists(srcdir):
+            shutil.copytree(testroot, srcdir, symlinks=False)
+
+        if docutilsconf is not None:
+            with open(os.path.join(srcdir, 'docutils.conf')) as f:
+                f.write(docutilsconf)
+
+        builddir = os.path.join(srcdir, '_build')
+#        if confdir is None:
+        confdir = srcdir
+#        if outdir is None:
+        outdir = os.path.join(builddir, buildername)
+        if not os.path.exists(outdir):
+            os.makedirs(outdir)
+
+        doctreedir = os.path.join(builddir, 'doctrees')
+        if not os.path.exists(doctreedir):
+            os.makedirs(doctreedir)
+        if confoverrides is None:
+            confoverrides = {}
+        if status is None:
+            status = StringIO()
+        if warning is None:
+            warning = ListOutput('stderr')
+#        if warningiserror is None:
+        warningiserror = False
+
+        self._saved_path = sys.path[:]
+        self._saved_directives = directives._directives.copy()
+        self._saved_roles = roles._roles.copy()
+
+        self._saved_nodeclasses = set(v for v in dir(nodes.GenericNodeVisitor)
+                                      if v.startswith('visit_'))
+
+        try:
+            application.Sphinx.__init__(self, srcdir, confdir, outdir, doctreedir,
+                                        buildername, confoverrides, status, warning,
+                                        freshenv, warningiserror, tags)
+        except:
+            self.cleanup()
+            raise
+
+    def cleanup(self, doctrees=False):
+        shutil.rmtree(self.__tempdir)
+        Theme.themes.clear()
+        AutoDirective._registry.clear()
+        ModuleAnalyzer.cache.clear()
+        LaTeXBuilder.usepackages = []
+        sys.path[:] = self._saved_path
+        sys.modules.pop('autodoc_fodder', None)
+        directives._directives = self._saved_directives
+        roles._roles = self._saved_roles
+        for method in dir(nodes.GenericNodeVisitor):
+            if method.startswith('visit_') and \
+               method not in self._saved_nodeclasses:
+                delattr(nodes.GenericNodeVisitor, 'visit_' + method[6:])
+                delattr(nodes.GenericNodeVisitor, 'depart_' + method[6:])
+
+    def __repr__(self):
+        return '<%s buildername=%r>' % (self.__class__.__name__, self.builder.name)

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,10 @@ with open(os.path.join(here, 'README.rst')) as f:
 with open(os.path.join(here, 'CHANGES.rst')) as f:
     CHANGES = f.read()
 
+tests_require = [
+    'zope.testrunner',
+]
+
 setup(name='repoze.sphinx.autointerface',
       version='0.8.1.dev0',
       description='Sphinx extension: auto-generates API docs '
@@ -50,11 +54,14 @@ setup(name='repoze.sphinx.autointerface',
       include_package_data=True,
       namespace_packages=['repoze', 'repoze.sphinx'],
       zip_safe=False,
-      tests_require = [],
-      install_requires=['zope.interface',
-                        'Sphinx>=0.6.1',
-                        'setuptools',
-                       ],
+      tests_require = tests_require,
+      install_requires=[
+          'zope.interface',
+          'Sphinx>=1.0',
+          'setuptools',
+      ],
+      extras_require = {
+          'test': tests_require,
+      },
       #test_suite="repoze.",
       )
-

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist =
+    py27,py33,py34,,py35,pypy
+
+[testenv]
+commands =
+    zope-testrunner --test-path={toxinidir}
+deps =
+    zope.testrunner


### PR DESCRIPTION
This borrows some code from the sphinx test suite (which they do not
distribute.)

Add tox and travis support.

Remove support for Sphinx < 1.0.

Remove helper unicode function since we dont run on 2.6 on 3.2 anymore.