### PR TITLE
Fix tests with Sphinx 7.2.x and 8.2.x

### DIFF
--- a/repoze/sphinx/tests/test_autointerface.py
+++ b/repoze/sphinx/tests/test_autointerface.py
@@ -29,6 +29,8 @@ class Options(dict):
     imported_members = False
     show_inheritance = False
     noindex = False
+    no_index = False
+    no_index_entry = False
     annotation = None
     synopsis = ''
     platform = ''


### PR DESCRIPTION
Fixes https://github.com/repoze/repoze.sphinx.autointerface/issues/21.  The old name is left in the dictionary for compatibility with Sphinx < 7.2.